### PR TITLE
Add replication enabled attribute in volume data-source

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_volume.go
+++ b/ibm/service/power/data_source_ibm_pi_volume.go
@@ -62,6 +62,57 @@ func DataSourceIBMPIVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"replication_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates if the volume should be replication enabled or not",
+			},
+			"replication_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Replication type(metro,global)",
+			},
+			"replication_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Replication status of a volume",
+			},
+			"auxiliary": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "true if volume is auxiliary otherwise false",
+			},
+			"consistency_group_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Consistency Group Name if volume is a part of volume group",
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Volume Group ID",
+			},
+			"mirroring_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Mirroring state for replication enabled volume",
+			},
+			"primary_role": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Indicates whether master/aux volume is playing the primary role",
+			},
+			"aux_volume_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Indicates auxiliary volume name",
+			},
+			"master_volume_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Indicates master volume name",
+			},
 		},
 	}
 }
@@ -87,6 +138,16 @@ func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("disk_type", volumedata.DiskType)
 	d.Set("volume_pool", volumedata.VolumePool)
 	d.Set("wwn", volumedata.Wwn)
+	d.Set("replication_enabled", volumedata.ReplicationEnabled)
+	d.Set("replication_type", volumedata.ReplicationType)
+	d.Set("replication_status", volumedata.ReplicationStatus)
+	d.Set("auxiliary", volumedata.Auxiliary)
+	d.Set("consistency_group_name", volumedata.ConsistencyGroupName)
+	d.Set("group_id", volumedata.GroupID)
+	d.Set("mirroring_state", volumedata.MirroringState)
+	d.Set("primary_role", volumedata.PrimaryRole)
+	d.Set("aux_volume_name", volumedata.AuxVolumeName)
+	d.Set("master_volume_name", volumedata.MasterVolumeName)
 
 	return nil
 }

--- a/ibm/service/power/data_source_ibm_pi_volume_test.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_test.go
@@ -21,6 +21,7 @@ func TestAccIBMPIVolumeDataSource_basic(t *testing.T) {
 				Config: testAccCheckIBMPIVolumeDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_pi_volume.testacc_ds_volume", "id"),
+					resource.TestCheckResourceAttr("data.ibm_pi_volume.testacc_ds_volume", "replication_enabled", "false"),
 				),
 			},
 		},
@@ -28,6 +29,32 @@ func TestAccIBMPIVolumeDataSource_basic(t *testing.T) {
 }
 
 func testAccCheckIBMPIVolumeDataSourceConfig() string {
+	return fmt.Sprintf(`
+data "ibm_pi_volume" "testacc_ds_volume" {
+    pi_volume_name = "%s"
+    pi_cloud_instance_id = "%s"
+}`, acc.Pi_volume_name, acc.Pi_cloud_instance_id)
+
+}
+
+func TestAccIBMPIVolumeDataSource_replication(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMPIVolumeDataSourceReplicationConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_pi_volume.testacc_ds_volume", "id"),
+					resource.TestCheckResourceAttr("data.ibm_pi_volume.testacc_ds_volume", "replication_enabled", "true"),
+					resource.TestCheckResourceAttrSet("data.ibm_pi_volume.testacc_ds_volume", "replication_status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMPIVolumeDataSourceReplicationConfig() string {
 	return fmt.Sprintf(`
 data "ibm_pi_volume" "testacc_ds_volume" {
     pi_volume_name = "%s"

--- a/website/docs/d/pi_volume.html.markdown
+++ b/website/docs/d/pi_volume.html.markdown
@@ -42,9 +42,19 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
+- `auxiliary` - (Bool) Indicates if the volume is auxiliary or not.
+- `aux_volume_name` - (String) The auxiliary volume name.
+- `consistency_group_name` - (String) Consistency group name if volume is a part of volume group.
 - `disk_type` - (String) The disk type that is used for the volume.
 - `bootable` -  (Bool) Indicates if the volume is boot capable.
+- `group_id` - (String) The volume group id in which the volume belongs.
 - `id` - (String) The unique identifier of the volume.
+- `master_volume_name` - (String) The master volume name.
+- `mirroring_state` - (String) Mirroring state for replication enabled volume.
+- `primary_role` - (String) Indicates whether `master`/`auxiliary` volume is playing the primary role.
+- `replication_enabled` - (Bool) Indicates if the volume should be replication enabled or not.
+- `replication_status` - (String) The replication status of the volume.
+- `replication_type` - (String) The replication type of the volume `metro` or `global`.
 - `shareable` - (String) Indicates if the volume is shareable between VMs. 
 - `size` - (Integer) The size of the volume in gigabytes.
 - `state` - (String) The state of the volume.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

=== RUN   TestAccIBMPIVolumeDataSource_basic
--- PASS: TestAccIBMPIVolumeDataSource_basic (83.29s)
PASS
=== RUN   TestAccIBMPIVolumeDataSource_replication
--- PASS: TestAccIBMPIVolumeDataSource_replication (45.70s)
PASS
```
